### PR TITLE
Conditional package (BZip2 and OpenSSL) inclusion

### DIFF
--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,8 +1,12 @@
 @PACKAGE_INIT@
 
 find_package(ZLIB CONFIG REQUIRED)
-find_package(BZip2 CONFIG REQUIRED)
-find_package(OpenSSL REQUIRED)
+if(ENABLE_BZIP2)
+  find_package(BZip2 CONFIG REQUIRED)
+endif()
+if(ENABLE_OPENSSL)
+  find_package(OpenSSL REQUIRED)
+endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
 check_required_components("@PROJECT_NAME@")


### PR DESCRIPTION
This fixes build without OpenSSL and BZip2 on windows